### PR TITLE
Expose lmdb::Iter publically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ extern crate lmdb_sys as ffi;
 pub use cursor::{
     Cursor,
     RoCursor,
-    RwCursor
+    RwCursor,
+    Iter
 };
 pub use database::Database;
 pub use environment::{Environment, EnvironmentBuilder};


### PR DESCRIPTION
I'm trying to make a newtype wrapper around it, and can't because it's in lmdb::cursor, which isn't public.