### PR TITLE
tweaks to enable windows builds with msvc

### DIFF
--- a/lmdb-sys/src/ffi.rs
+++ b/lmdb-sys/src/ffi.rs
@@ -62,7 +62,7 @@ extern "C" {
     pub fn mdb_version(major: *mut ::libc::c_int, minor: *mut ::libc::c_int, patch: *mut ::libc::c_int) -> *mut ::libc::c_char;
     pub fn mdb_strerror(err: ::libc::c_int) -> *mut ::libc::c_char;
     pub fn mdb_env_create(env: *mut *mut MDB_env) -> ::libc::c_int;
-    pub fn mdb_env_open(env: *mut MDB_env, path: *const ::libc::c_char, flags: ::libc::c_uint, mode: ::libc::mode_t) -> ::libc::c_int;
+    pub fn mdb_env_open(env: *mut MDB_env, path: *const ::libc::c_char, flags: ::libc::c_uint, mode: super::mode_t) -> ::libc::c_int;
     pub fn mdb_env_copy(env: *mut MDB_env, path: *const ::libc::c_char) -> ::libc::c_int;
     pub fn mdb_env_copyfd(env: *mut MDB_env, fd: ::libc::c_int) -> ::libc::c_int;
     pub fn mdb_env_copy2(env: *mut MDB_env, path: *const ::libc::c_char, flags: ::libc::c_uint) -> ::libc::c_int;

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -2,6 +2,13 @@
 
 extern crate libc;
 
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+pub type mode_t = ::libc::mode_t;
+#[cfg(windows)]
+#[allow(non_camel_case_types)]
+pub type mode_t = ::libc::c_int;
+
 pub use constants::*;
 pub use ffi::*;
 


### PR DESCRIPTION
bumped version to 0.5.1

Since the libc crate doesn't export a type for mode_t on windows-msvc I've just taken the same approach used by lmdb [itself](https://github.com/LMDB/lmdb/blob/mdb.master/libraries/liblmdb/lmdb.h#L177) and defined mode_t to be a libc::c_int within environment.rs

The other big thing missing on Windows is `OsStrExt::as_bytes` which I've bundled a potential solution for. 

I'm going to submit a PR for the std crate as well so that perhaps down the road that won't be needed.

An alternative to the solution here could be to change how you're building the CString from a Path in order to find a more general solution that wouldn't require the trait I provided. 
I'm happy to scrap this trait and attempt that if you'd prefer it.