### PR TITLE
Disable rustfmt by default

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
This effects issue #11.

This change disables rustfmt from reformatting any code in this project.

This change will cause no changes for people not using rustfmt. Whereas, for people who have their editor set up to automatically reformat Rust code, this change will cause their editor to not make any rustfmt-related changes. I.e., this pull request makes it so that rustfmt-using people will not need to disable rustfmt manually before hacking on this project.

Later, if and when this project switches to using rustfmt, the `.rustfmt.toml` file would be modified to specify whatever rustfmt settings are desired.