### PR TITLE
Update lmdb-sys to latest version and add database statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ cargo build
 * [x] Cursors.
 * [x] Zero-copy put API.
 * [x] Nested transactions.
-* [ ] Database statistics.
+* [x] Database statistics.

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -20,5 +20,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-# https://github.com/alexcrichton/gcc-rs/issues/240
-gcc = "=0.3.51"
+cc = "1"

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -1,5 +1,5 @@
 extern crate pkg_config;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
@@ -11,7 +11,7 @@ fn main() {
     lmdb.push("liblmdb");
 
     if !pkg_config::find_library("liblmdb").is_ok() {
-        gcc::Config::new()
+        cc::Build::new()
                     .file(lmdb.join("mdb.c"))
                     .file(lmdb.join("midl.c"))
                     // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,5 @@
 use libc::{c_uint, size_t};
-use std::{fmt, ptr, result};
+use std::{fmt, ptr, result, mem};
 use std::ffi::CString;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -34,6 +34,11 @@ pub struct Environment {
     env: *mut ffi::MDB_env,
     dbi_open_mutex: Mutex<()>,
 }
+
+/// Database statistics
+///
+/// Contains information about the size and layout of an LMDB database
+pub struct Stat(ffi::MDB_stat);
 
 impl Environment {
 
@@ -150,6 +155,53 @@ impl Environment {
     /// `Error::BadValSize` (since the DB name is gone).
     pub unsafe fn close_db(&mut self, db: Database) {
         ffi::mdb_dbi_close(self.env, db.dbi());
+    }
+
+    /// Get database statistics
+    pub fn stat(&self) -> Result<Stat> {
+        unsafe {
+            let mut stat: Stat = mem::uninitialized();
+            lmdb_try!(ffi::mdb_env_stat(self.env(), &mut stat.0));
+            Ok(stat)
+        }
+    }
+}
+
+impl Stat {
+    /// Size of database in bytes
+    #[inline]
+    pub fn size(&self) -> u32 {
+        self.0.ms_psize
+    }
+
+    /// Height of B-tree
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        self.0.ms_depth
+    }
+
+    /// Number of internal (non-leaf) pages
+    #[inline]
+    pub fn branch_pages(&self) -> usize {
+        self.0.ms_branch_pages
+    }
+
+    /// Number of lead pages
+    #[inline]
+    pub fn leaf_pages(&self) -> usize {
+        self.0.ms_leaf_pages
+    }
+
+    /// Number of overflow pages
+    #[inline]
+    pub fn overflow_pages(&self) -> usize {
+        self.0.ms_overflow_pages
+    }
+
+    /// Number of data items
+    #[inline]
+    pub fn entries(&self) -> usize {
+        self.0.ms_entries
     }
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -160,7 +160,7 @@ impl Environment {
     /// Get database statistics
     pub fn stat(&self) -> Result<Stat> {
         unsafe {
-            let mut stat: Stat = mem::uninitialized();
+            let mut stat = Stat(mem::uninitialized());
             lmdb_try!(ffi::mdb_env_stat(self.env(), &mut stat.0));
             Ok(stat)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use cursor::{
     IterDup,
 };
 pub use database::Database;
-pub use environment::{Environment, EnvironmentBuilder};
+pub use environment::{Environment, Stat, EnvironmentBuilder};
 pub use error::{Error, Result};
 pub use flags::*;
 pub use transaction::{


### PR DESCRIPTION
While updating the LMDB source to the latest version I also switched from using the `gcc` crate to the `cc` crate.

I also just added a way of accessing database statistics via the `stat` method of `Environment`, which returns a new struct called `Stat` (a thin wrapper around MDB_stat)

Thanks