### PR TITLE
Swap out gcc crate for cc

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -20,5 +20,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-# https://github.com/alexcrichton/gcc-rs/issues/240
-gcc = "=0.3.51"
+cc = "1.0"

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -1,5 +1,5 @@
 extern crate pkg_config;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
@@ -11,7 +11,7 @@ fn main() {
     lmdb.push("liblmdb");
 
     if !pkg_config::find_library("liblmdb").is_ok() {
-        gcc::Config::new()
+        cc::Build::new()
                     .file(lmdb.join("mdb.c"))
                     .file(lmdb.join("midl.c"))
                     // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25


### PR DESCRIPTION
The gcc crate has been renamed and generalised to `cc` create.  Use it to leverage support for more compilation targets.