### PR TITLE
iter getter test that segfaults

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -317,6 +317,7 @@ mod test {
     use flags::*;
     use super::*;
     use test_utils::*;
+    use transaction::RoTransaction;
 
     #[test]
     fn test_get() {
@@ -591,5 +592,22 @@ mod test {
             assert_eq!(count, n);
             mdb_cursor_close(cursor);
         });
+    }
+
+    /// "error: process didn't exit successfully…
+    /// (signal: 11, SIGSEGV: invalid memory reference)"
+    #[test]
+    fn test_iter_getter_segfaults() {
+        let dir = TempDir::new("test").unwrap();
+        let env = Environment::new().open(dir.path()).unwrap();
+        let db = env.open_db(None).unwrap();
+        let txn = env.begin_ro_txn().unwrap();
+
+        fn get_iter<'a>(db: Database, txn: &'a RoTransaction<'a>) -> Iter {
+            let mut cursor = txn.open_ro_cursor(db).unwrap();
+            cursor.iter()
+        }
+
+        let _result: Vec<_> = get_iter(db, &txn).collect();
     }
 }


### PR DESCRIPTION
This test demonstrates a segfault when returning an Iter from a function that also creates (and then drops) the Cursor with which the Iter is created. Presumably the issue is that dropping the Cursor calls `mdb_cursor_close()` on the MDB_cursor pointer, after which the Iter tries to use that pointer.

`Cursor.cursor()` says that "the caller **must** ensure that the pointer is not used after the lifetime of the cursor." But the Iter implementation doesn't enforce that constraint. And while direct consumers of `Cursor.cursor()` can't say they weren't warned, the same isn't true for indirect consumers who are calling the iter getters like `Cursor.iter()` (and potentially wrapping them in their own getter functions). Which makes them a footgun.