### PR TITLE
Fix Android cross-compile build`cargo build --target armv7-linux-an…

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -5,17 +5,23 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    let target = env::var("TARGET").expect("No TARGET found");
     let mut lmdb: PathBuf = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
     lmdb.push("lmdb");
     lmdb.push("libraries");
     lmdb.push("liblmdb");
 
     if !pkg_config::find_library("liblmdb").is_ok() {
-        cc::Build::new()
-                    .file(lmdb.join("mdb.c"))
-                    .file(lmdb.join("midl.c"))
-                    // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25
-                    .opt_level(2)
-                    .compile("liblmdb.a")
+        let target = env::var("TARGET").expect("No TARGET found");
+        let mut build = cc::Build::new();
+        if target.contains("android") {
+            build.define("ANDROID", "1");
+        }
+        build
+            .file(lmdb.join("mdb.c"))
+            .file(lmdb.join("midl.c"))
+            // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25
+            .opt_level(2)
+            .compile("liblmdb.a")
     }
 }


### PR DESCRIPTION
Cross-compiling this crate for android currently fails; here is the command I am using to build:

`cargo build --target armv7-linux-androideabi`

This PR resolves that build failure.

To try this out, be sure to:
* Have the Android NDK configured with the toolchain available on your PATH.
* Install the target via `rustup target install armv7-linux-androideabi`