### PR TITLE
Update pkg-config dependency to 0.3.2

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -19,5 +19,5 @@ build = "build.rs"
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.2"
 cc = "1"


### PR DESCRIPTION
Earlier versions of pkg-config don't build with any post-1.0 rust
compiler.

This is an attempt to get lmdb, and some non-trivial crates which depend
on it, building with `-Z minimal-versions`. See
https://github.com/rust-lang/cargo/issues/5657 for more information.