### PR TITLE
use feature to enable unstable tests/benches on nightly Rust

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,17 @@
 environment:
   matrix:
     - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: stable
     - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: stable
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: nightly
 
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -Vv
   - cargo -V
@@ -17,6 +23,9 @@ test_script:
   - SET RUST_BACKTRACE=1
   - cargo test --target %TARGET% --all -v
   - cargo test --release --target %TARGET% --all -v
+  # Benchmark results on CI are untrustworthy, but it's still useful
+  # to confirm that they compile.
+  - if "%RUST_VERSION%" == "nightly" cargo bench --no-run --features nightly
 
 cache:
   - C:\Users\appveyor\.cargo\registry

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ rust:
 
 script:
   - cargo build --verbose
+  - env RUST_BACKTRACE=1 cargo test --all -v
+  - env RUST_BACKTRACE=1 cargo test --all -v --release
+
   - if [[ $TRAVIS_RUST_VERSION = nightly* ]]; then
-      env RUST_BACKTRACE=1 cargo test --all -v;
-      env RUST_BACKTRACE=1 cargo test --all -v --release;
+      env RUST_BACKTRACE=1 cargo bench --no-run --features nightly;
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ lmdb-sys = { version = "0.8.0", path = "lmdb-sys" }
 rand = "0.4"
 tempdir = "0.3"
 byteorder = "1.0"
+
+[features]
+nightly = []

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -303,7 +303,9 @@ impl <'txn> Iterator for IterDup<'txn> {
 #[cfg(test)]
 mod test {
 
+    #[cfg(feature = "nightly")]
     use std::ptr;
+    #[cfg(feature = "nightly")]
     use test::{Bencher, black_box};
 
     use tempdir::TempDir;
@@ -312,6 +314,7 @@ mod test {
     use ffi::*;
     use flags::*;
     use super::*;
+    #[cfg(feature = "nightly")]
     use test_utils::*;
 
     #[test]
@@ -559,6 +562,7 @@ mod test {
     }
 
     /// Benchmark of iterator sequential read performance.
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_get_seq_iter(b: &mut Bencher) {
         let n = 100;
@@ -582,6 +586,7 @@ mod test {
     }
 
     /// Benchmark of cursor sequential read performance.
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_get_seq_cursor(b: &mut Bencher) {
         let n = 100;
@@ -605,6 +610,7 @@ mod test {
     }
 
     /// Benchmark of raw LMDB sequential read performance (control).
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_get_seq_raw(b: &mut Bencher) {
         let n = 100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Idiomatic and safe APIs for interacting with the
 //! [Lightning Memory-mapped Database (LMDB)](https://symas.com/lmdb).
 
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/lmdb/0.8.0")]
 
@@ -10,7 +10,7 @@ extern crate lmdb_sys as ffi;
 
 #[cfg(test)] extern crate rand;
 #[cfg(test)] extern crate tempdir;
-#[cfg(test)] extern crate test;
+#[cfg(all(test, feature = "nightly"))] extern crate test;
 #[macro_use] extern crate bitflags;
 
 pub use cursor::{
@@ -69,14 +69,17 @@ mod test_utils {
 
     use super::*;
 
+    #[cfg(feature = "nightly")]
     pub fn get_key(n: u32) -> String {
         format!("key{}", n)
     }
 
+    #[cfg(feature = "nightly")]
     pub fn get_data(n: u32) -> String {
         format!("data{}", n)
     }
 
+    #[cfg(feature = "nightly")]
     pub fn setup_bench_db<'a>(num_rows: u32) -> (TempDir, Environment) {
         let dir = TempDir::new("test").unwrap();
         let env = Environment::new().open(dir.path()).unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -376,21 +376,27 @@ impl <'env> Transaction for RwTransaction<'env> {
 #[cfg(test)]
 mod test {
 
+    #[cfg(feature = "nightly")]
     use libc::size_t;
+    #[cfg(feature = "nightly")]
     use rand::{Rng, XorShiftRng};
     use std::io::Write;
+    #[cfg(feature = "nightly")]
     use std::ptr;
     use std::sync::{Arc, Barrier};
     use std::thread::{self, JoinHandle};
+    #[cfg(feature = "nightly")]
     use test::{Bencher, black_box};
 
     use tempdir::TempDir;
 
     use environment::*;
     use error::*;
+    #[cfg(feature = "nightly")]
     use ffi::*;
     use flags::*;
     use super::*;
+    #[cfg(feature = "nightly")]
     use test_utils::*;
 
     #[test]
@@ -596,6 +602,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_get_rand(b: &mut Bencher) {
         let n = 100u32;
@@ -615,6 +622,7 @@ mod test {
         });
     }
 
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_get_rand_raw(b: &mut Bencher) {
         let n = 100u32;
@@ -645,6 +653,7 @@ mod test {
         });
     }
 
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_put_rand(b: &mut Bencher) {
         let n = 100u32;
@@ -663,6 +672,7 @@ mod test {
         });
     }
 
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_put_rand_raw(b: &mut Bencher) {
         let n = 100u32;


### PR DESCRIPTION
@danburkert One strategy for running unstable tests/benches on nightly Rust—while still being able to run stable tests on stable Rust—is to create a feature that enables the unstable tests and then enable that feature only when compiling with nightly Rust.

This is discussed in https://internals.rust-lang.org/t/setting-cfg-nightly-on-nightly-by-default/1893/22, and https://github.com/hyperium/hyper uses it. This branch implements that strategy for lmdb-rs, which makes it possible to re-enable stable tests on stable Rust.

I suspect that converting to Criterion is a better long-term strategy. I recently converted https://github.com/mykmelez/kv-bench/ to Criterion, and it was reasonably straightforward (and unlocked additional capabilities). Nevertheless, this might be a worthwhile short-term fix.
