### PR TITLE
return error result from fallible iteration methods

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -602,10 +602,6 @@ mod test {
                 let mut i = 0;
                 let mut count = 0u32;
                 for result in cursor.iter() {
-                    // let (key, data) = match result {
-                    //     Ok((key, data)) => (key, data),
-                    //     Err(error) => return Err(error),
-                    // };
                     let (key, data) = result?;
                     i = i + key.len() + data.len();
                     count = count + 1;

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -434,8 +434,13 @@ mod test {
         let txn = env.begin_ro_txn().unwrap();
         let mut cursor = txn.open_ro_cursor(db).unwrap();
 
+        // Because Result implements FromIterator, we can collect the iterator
+        // of items of type Result<_, E> into a Result<Vec<_, E>> by specifying
+        // the collection type via the turbofish syntax.
         assert_eq!(items, cursor.iter().collect::<Result<Vec<_>>>().unwrap());
-        let retr: Result<Vec<_>> = cursor.iter().collect();
+
+        // Alternately, we can collect it into an appropriately typed variable.
+        let retr: Result<Vec<_>> = cursor.iter_start().collect();
         assert_eq!(items, retr.unwrap());
 
         cursor.get(Some(b"key2"), None, MDB_SET).unwrap();


### PR DESCRIPTION
This branch implements the suggestion in #42 by returning an error result from fallible iteration methods (`Cursor.iter*()` and `Iterator.next()`) when those methods fail. See that issue for more info about the changes.