### PR TITLE
correct size of default memory map

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -316,7 +316,7 @@ impl EnvironmentBuilder {
     /// Sets the size of the memory map to use for the environment.
     ///
     /// The size should be a multiple of the OS page size. The default is
-    /// 10485760 bytes. The size of the memory map is also the maximum size
+    /// 1048576 bytes. The size of the memory map is also the maximum size
     /// of the database. The value should be chosen as large as possible,
     /// to accommodate future growth of the database. It may be increased at
     /// later times.


### PR DESCRIPTION
The LMDB docs for [mdb_env_set_mapsize](http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5) says that the default map size is 10,485,760 bytes, i.e. 10MiB. But the [`DEFAULT_MAPSIZE` define](https://github.com/LMDB/lmdb/blob/26c7df88e44e31623d0802a564f24781acdefde3/libraries/liblmdb/mdb.c#L729) in the LMDB code sets the default map size to 1,048,576 bytes, i.e. 1MiB.

I submitted a patch to fix the LMDB docs in [issue 8322](https://www.openldap.org/its/index.cgi/Incoming?id=8322). That issue has been open for several years, and it isn't clear whether it's the docs or the `DEFAULT_MAPSIZE` define that is incorrect. But I suspect the former, since the comment above `DEFAULT_MAPSIZE` says it's "certainly too small for any actual applications," which suggests that the smaller size was intentional.

In any case, it's worth fixing the lmdb-rs docs to specify the correct value (even if the LMDB docs specify an incorrect one).
