### PR TITLE
stop building with Rust 1.20 in automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 
 rust:
-- 1.20.0
+- 1.30.0
 - stable
 - nightly
 


### PR DESCRIPTION
The latest version of cc, version [1.0.27](https://crates.io/crates/cc/1.0.27), requires [str.trim_end_matches()](https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_end_matches), which was introduced in Rust 1.30, so this project won't build anymore with Rust 1.20. Thus we should stop building it with that version in automation.

(Alternately, we could pin cc to the previous version 1.0.26, but that seems undesirable, given that we want to continue to get future patch-level fixes to that crate.)
