### PR TITLE
add stat() for sub-database to txn 

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,5 @@
 use libc::{c_uint, size_t};
-use std::{fmt, ptr, result, mem};
+use std::{fmt, ptr, result};
 use std::ffi::CString;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -12,6 +12,7 @@ use ffi;
 
 use error::{Result, lmdb_result};
 use database::Database;
+use stat::Stat;
 use transaction::{RoTransaction, RwTransaction, Transaction};
 use flags::{DatabaseFlags, EnvironmentFlags};
 
@@ -158,53 +159,10 @@ impl Environment {
     /// Retrieves statistics about this environment.
     pub fn stat(&self) -> Result<Stat> {
         unsafe {
-            let mut stat = Stat(mem::zeroed());
-            lmdb_try!(ffi::mdb_env_stat(self.env(), &mut stat.0));
+            let mut stat = Stat::new();
+            lmdb_try!(ffi::mdb_env_stat(self.env(), stat.stat()));
             Ok(stat)
         }
-    }
-}
-
-/// Environment statistics.
-///
-/// Contains information about the size and layout of an LMDB environment.
-pub struct Stat(ffi::MDB_stat);
-
-impl Stat {
-    /// Size of a database page. This is the same for all databases in the environment.
-    #[inline]
-    pub fn page_size(&self) -> u32 {
-        self.0.ms_psize
-    }
-
-    /// Depth (height) of the B-tree.
-    #[inline]
-    pub fn depth(&self) -> u32 {
-        self.0.ms_depth
-    }
-
-    /// Number of internal (non-leaf) pages.
-    #[inline]
-    pub fn branch_pages(&self) -> usize {
-        self.0.ms_branch_pages
-    }
-
-    /// Number of leaf pages.
-    #[inline]
-    pub fn leaf_pages(&self) -> usize {
-        self.0.ms_leaf_pages
-    }
-
-    /// Number of overflow pages.
-    #[inline]
-    pub fn overflow_pages(&self) -> usize {
-        self.0.ms_overflow_pages
-    }
-
-    /// Number of data items.
-    #[inline]
-    pub fn entries(&self) -> usize {
-        self.0.ms_entries
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ pub use cursor::{
     IterDup,
 };
 pub use database::Database;
-pub use environment::{Environment, Stat, EnvironmentBuilder};
+pub use environment::{Environment, EnvironmentBuilder};
+pub use stat::Stat;
 pub use error::{Error, Result};
 pub use flags::*;
 pub use transaction::{
@@ -56,6 +57,7 @@ mod flags;
 mod cursor;
 mod database;
 mod environment;
+mod stat;
 mod error;
 mod transaction;
 

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -1,0 +1,61 @@
+use ffi;
+use std::mem;
+
+/// Environment statistics.
+///
+/// Contains information about the size and layout of an LMDB environment.
+pub struct Stat(ffi::MDB_stat);
+
+impl Stat {
+    /// Create new zero'd LMDB statistics.
+    pub fn new() -> Stat {
+        unsafe {
+            Stat(mem::zeroed())
+        }
+    }
+
+    /// Returns a raw pointer to the underlying LMDB statistics.
+    ///
+    /// The caller **must** ensure that the pointer is not dereferenced after the lifetime of the
+    /// stat.
+    pub fn stat(&mut self) -> *mut ffi::MDB_stat {
+        &mut self.0
+    }
+
+    /// Size of a database page. This is the same for all databases in the environment.
+    #[inline]
+    pub fn page_size(&self) -> u32 {
+        self.0.ms_psize
+    }
+
+    /// Depth (height) of the B-tree.
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        self.0.ms_depth
+    }
+
+    /// Number of internal (non-leaf) pages.
+    #[inline]
+    pub fn branch_pages(&self) -> usize {
+        self.0.ms_branch_pages
+    }
+
+    /// Number of leaf pages.
+    #[inline]
+    pub fn leaf_pages(&self) -> usize {
+        self.0.ms_leaf_pages
+    }
+
+    /// Number of overflow pages.
+    #[inline]
+    pub fn overflow_pages(&self) -> usize {
+        self.0.ms_overflow_pages
+    }
+
+    /// Number of data items.
+    #[inline]
+    pub fn entries(&self) -> usize {
+        self.0.ms_entries
+    }
+}
+

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -7,6 +7,7 @@ use ffi;
 use cursor::{RoCursor, RwCursor};
 use environment::Environment;
 use database::Database;
+use stat::Stat;
 use error::{Error, Result, lmdb_result};
 use flags::{DatabaseFlags, EnvironmentFlags, WriteFlags};
 
@@ -106,53 +107,10 @@ pub trait Transaction : Sized {
     /// Retrieves statistics about a database.
     fn stat<'txn>(&'txn self, database: Database) -> Result<Stat> {
         unsafe {
-            let mut stat = Stat(mem::zeroed());
-            lmdb_try!(ffi::mdb_stat(self.txn(), database.dbi(), &mut stat.0));
+            let mut stat = Stat::new();
+            lmdb_try!(ffi::mdb_stat(self.txn(), database.dbi(), stat.stat()));
             Ok(stat)
         }
-    }
-}
-
-/// Database statistics.
-///
-/// Contains information about the size and layout of an LMDB database.
-pub struct Stat(ffi::MDB_stat);
-
-impl Stat {
-    /// Size of a database page. This is the same for all databases in the environment.
-    #[inline]
-    pub fn page_size(&self) -> u32 {
-        self.0.ms_psize
-    }
-
-    /// Depth (height) of the B-tree.
-    #[inline]
-    pub fn depth(&self) -> u32 {
-        self.0.ms_depth
-    }
-
-    /// Number of internal (non-leaf) pages.
-    #[inline]
-    pub fn branch_pages(&self) -> usize {
-        self.0.ms_branch_pages
-    }
-
-    /// Number of leaf pages.
-    #[inline]
-    pub fn leaf_pages(&self) -> usize {
-        self.0.ms_leaf_pages
-    }
-
-    /// Number of overflow pages.
-    #[inline]
-    pub fn overflow_pages(&self) -> usize {
-        self.0.ms_overflow_pages
-    }
-
-    /// Number of data items.
-    #[inline]
-    pub fn entries(&self) -> usize {
-        self.0.ms_entries
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -102,6 +102,58 @@ pub trait Transaction : Sized {
         }
         Ok(DatabaseFlags::from_bits_truncate(flags))
     }
+
+    /// Retrieves statistics about a database.
+    fn stat<'txn>(&'txn self, database: Database) -> Result<Stat> {
+        unsafe {
+            let mut stat = Stat(mem::zeroed());
+            lmdb_try!(ffi::mdb_stat(self.txn(), database.dbi(), &mut stat.0));
+            Ok(stat)
+        }
+    }
+}
+
+/// Database statistics.
+///
+/// Contains information about the size and layout of an LMDB database.
+pub struct Stat(ffi::MDB_stat);
+
+impl Stat {
+    /// Size of a database page. This is the same for all databases in the environment.
+    #[inline]
+    pub fn page_size(&self) -> u32 {
+        self.0.ms_psize
+    }
+
+    /// Depth (height) of the B-tree.
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        self.0.ms_depth
+    }
+
+    /// Number of internal (non-leaf) pages.
+    #[inline]
+    pub fn branch_pages(&self) -> usize {
+        self.0.ms_branch_pages
+    }
+
+    /// Number of leaf pages.
+    #[inline]
+    pub fn leaf_pages(&self) -> usize {
+        self.0.ms_leaf_pages
+    }
+
+    /// Number of overflow pages.
+    #[inline]
+    pub fn overflow_pages(&self) -> usize {
+        self.0.ms_overflow_pages
+    }
+
+    /// Number of data items.
+    #[inline]
+    pub fn entries(&self) -> usize {
+        self.0.ms_entries
+    }
 }
 
 /// An LMDB read-only transaction.


### PR DESCRIPTION
This PR adds a `.stat()` routine to transaction objects so that a caller may inspect statistics for a specific database. This is useful when there are multiple databases open in a single environment.

Please don't hesitate to provide feedback or further requests, as I'm still coming to terms with Rust, esp. `unsafe`.