### PR TITLE
Make the argument's name of `set_max_dbs` consistent

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -308,8 +308,8 @@ impl EnvironmentBuilder {
     /// Currently a moderate number of slots are cheap but a huge number gets
     /// expensive: 7-120 words per transaction, and every `Transaction::open_db`
     /// does a linear search of the opened slots.
-    pub fn set_max_dbs(&mut self, max_readers: c_uint) -> &mut EnvironmentBuilder {
-        self.max_dbs = Some(max_readers);
+    pub fn set_max_dbs(&mut self, max_dbs: c_uint) -> &mut EnvironmentBuilder {
+        self.max_dbs = Some(max_dbs);
         self
     }
 


### PR DESCRIPTION
Hi,

This was confusing to the reader of the documentation.

It looks like this was copy/pasted, but the argument was not changed :D .

Thanks,