### PR TITLE
Search lmdb library also by name "lmdb"

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -10,7 +10,7 @@ fn main() {
     lmdb.push("libraries");
     lmdb.push("liblmdb");
 
-    if !pkg_config::find_library("liblmdb").is_ok() {
+    if !pkg_config::find_library("lmdb").is_ok() && !pkg_config::find_library("liblmdb").is_ok() {
         let target = env::var("TARGET").expect("No TARGET found");
         let mut build = cc::Build::new();
         if target.contains("android") {


### PR DESCRIPTION
Most distributions provide `lmdb.pc`, not `liblmdb.pc`.